### PR TITLE
[mag242] fixed mixins issues

### DIFF
--- a/view/frontend/web/js/setAdditionalParams.js
+++ b/view/frontend/web/js/setAdditionalParams.js
@@ -17,7 +17,8 @@ define([
                     uid: this.uid
                 };
             }
-            this._super();
+
+            return this._super();
         }
     };
 


### PR DESCRIPTION
According to Magento documentation ( https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html ) mixin MUST returns an object (here, `this._super()`). Otherwise, when the function is called, it will return `undefined` instead of expected.