### PR TITLE
[mag242] validator widget mixin fix

### DIFF
--- a/view/frontend/web/js/telephoneValidatorAddress.js
+++ b/view/frontend/web/js/telephoneValidatorAddress.js
@@ -1,19 +1,23 @@
 define([
     'jquery',
-    'intlTelInput'
+    'intlTelInput',
+    'jquery/validate'
 ], function ($, intlTelInput) {
     'use strict';
 
-    return function () {
-
-        const errorMap = ['Invalid telephone number', 'Invalid country code', 'Telephone number is too short', 'Telephone number is too long', 'Invalid telephone number'];
-
-        let validatorObj = {
-            /**
-             * @param {String} value
-             */
+    var errorMap = [
+            'Invalid telephone number',
+            'Invalid country code',
+            'Telephone number is too short',
+            'Telephone number is too long',
+            'Invalid telephone number'
+        ],
+        validatorObj = {
             validate: function (value) {
-                let countryCodeClass = $('.iti__selected-flag .iti__flag').attr('class');
+                var countryCodeClass = $('.iti__selected-flag .iti__flag').attr('class'),
+                    countryCode,
+                    isValid;
+
                 countryCodeClass = countryCodeClass.split(' ')[1];
 
                 if (countryCodeClass === undefined) {
@@ -22,8 +26,8 @@ define([
                     return false;
                 }
 
-                let countryCode = countryCodeClass.split('__')[1];
-                let isValid = intlTelInputUtils.isValidNumber(value, countryCode);
+                countryCode = countryCodeClass.split('__')[1];
+                isValid = intlTelInputUtils.isValidNumber(value, countryCode);
 
                 if (!isValid) {
                     $.validator.messages['validate-phone-number'] = errorMap[
@@ -33,12 +37,15 @@ define([
 
                 return isValid;
             }
-        }
+        };
 
-        $.validator.addMethod(
-            'validate-phone-number',
-            validatorObj.validate,
-            $.validator.messages['validate-phone-number']
-        );
+    $.validator.addMethod(
+        'validate-phone-number',
+        validatorObj.validate,
+        $.validator.messages['validate-phone-number']
+    );
+
+    return function (widget) {
+        return widget;
     };
 });


### PR DESCRIPTION
File telephoneValidatorAddress defined as mixin for 'mage/validation' js. In this file Adding a method to the jQuery validator goes wrong. This mixin MUST returns a widget. Because of this, it is impossible to write another mixin for file "mage/validation".